### PR TITLE
Add support for Mac profiles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
 
 # Metrics and Length Conventions
 
+Metrics/ClassLength:
+  Max: 150
+
 Metrics/MethodLength:
   Max: 30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file lists the changes for various versions of the `pprof` gem.
 ## 1.0.0
 
 * Add support Mac Profiles (`*.provisionprofile`) alongside the already-supported iOS Profiles (`*.mobileprovision`).
+* Add `--platform` filter to only list profiles that support a given platform (`OSX`, `iOS`, …)
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file lists the changes for various versions of the `pprof` gem.
 
+## 1.0.0
+
+* Add support Mac Profiles (`*.provisionprofile`) alongside the already-supported iOS Profiles (`*.mobileprovision`).
+
 ## 0.5.1
 
 * Fix an issue with `-j`/`--json` when used with list mode, so that it can now take `-c` and `-d` flags into account to include (or not) the certificates and devices in the JSON output list mode.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ end
 
 # And you can easily loop on all provisioning profiles and manipulate each
 dir = PProf::ProvisioningProfile::DEFAULT_DIR
-Dir["#{dir}/*.mobileprovision"].each do |file|
+# `*.mobileprovision` are typically for iOS profiles, `*.provisionprofile` for Mac profiles
+Dir["#{dir}/*.{mobileprovision,provisionprofile}"].each do |file|
   p = PProf::ProvisioningProfile.new(file)
   puts p.name
 end

--- a/bin/pprof
+++ b/bin/pprof
@@ -88,6 +88,10 @@ parser = OptionParser.new do |opts|
     filters[:appid] = matcher(appid)
   end
 
+  opts.on('--platform PLATFORM', 'Filter by Platform (OSX, iOS, xrOS/visionOS, …)') do |platform|
+    filters[:platform] = platform
+  end
+
   opts.on('--uuid UUID', 'Filter by UUID') do |uuid|
     filters[:uuid] = matcher(uuid)
   end

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -7,7 +7,7 @@ module PProf
   # A helper tool to pretty-print Provisioning Profile informations
   class OutputFormatter
     # List of properties of a `PProf::ProvisioningProfile` to print when using the `-i` flag
-    MAIN_PROFILE_KEYS = %i[name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name]
+    MAIN_PROFILE_KEYS = %i[name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name].freeze
 
     # Initialize a new OutputFormatter
     #
@@ -203,19 +203,19 @@ module PProf
 
     # Prints the filtered list of UUIDs or Paths only
     #
-    # @param [String] dir
-    #        The directory containing the mobileprovision/provisionprofile files to list.
-    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     # @param [Hash] options
     #        The options hash typically filled while parsing the command line arguments.
     #         - :mode: will print the UUIDs if set to `:list`, the file path otherwise
     #         - :zero: will concatenate the entries with `\0` instead of `\n` if set
+    # @param [String] dir
+    #        The directory containing the mobileprovision/provisionprofile files to list.
+    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     #
     # @yield each provisioning profile for filtering/validation
     #        The block is given ProvisioningProfile object and should
     #        return true to display the row, false to filter it out
     #
-    def print_list(dir: PProf::ProvisioningProfile::DEFAULT_DIR, options:) # rubocop:disable Style/OptionalArguments
+    def print_list(options:, dir: PProf::ProvisioningProfile::DEFAULT_DIR)
       errors = []
       Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
         file = File.join(dir, file_name)
@@ -232,19 +232,19 @@ module PProf
 
     # Prints the filtered list of profiles as a JSON array
     #
-    # @param [String] dir
-    #        The directory containing the mobileprovision/provisionprofile files to list.
-    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     # @param [Hash] options
     #        The options hash typically filled while parsing the command line arguments.
     #         - :certs: will print the UUIDs if set to `:list`, the file path otherwise
     #         - :devices: will concatenate the entries with `\0` instead of `\n` if set
+    # @param [String] dir
+    #        The directory containing the mobileprovision/provisionprofile files to list.
+    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     #
     # @yield each provisioning profile for filtering/validation
     #        The block is given ProvisioningProfile object and should
     #        return true to display the row, false to filter it out
     #
-    def print_json_list(dir: PProf::ProvisioningProfile::DEFAULT_DIR, options:) # rubocop:disable Style/OptionalArguments
+    def print_json_list(options:, dir: PProf::ProvisioningProfile::DEFAULT_DIR)
       errors = []
       profiles = Dir['*.{mobileprovision,provisionprofile}', base: dir].map do |file_name|
         file = File.join(dir, file_name)

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -157,6 +157,7 @@ module PProf
           (filters[:has_devices].nil? || !(p.provisioned_devices || []).empty? == filters[:has_devices]) &&
           (filters[:all_devices].nil? || p.provisions_all_devices == filters[:all_devices]) &&
           (filters[:aps_env].nil? || match_aps_env(p.entitlements.aps_environment, filters[:aps_env])) &&
+          (filters[:platform].nil? || p.platform.include?(filters[:platform])) &&
           true
       end
     end

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -164,7 +164,7 @@ module PProf
     # Prints the filtered list as a table
     #
     # @param [String] dir
-    #        The directory containing the mobileprovision files to list.
+    #        The directory containing the mobileprovision/provisionprofile files to list.
     #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     #
     # @yield each provisioning provile for filtering/validation
@@ -180,7 +180,7 @@ module PProf
       @output.puts table.row('UUID', 'Name', 'AppID', 'Expiration Date', ' ', 'Team Name')
       @output.puts table.separator
 
-      Dir['*.mobileprovision', base: dir].each do |file_name|
+      Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
         file = File.join(dir, file_name)
         begin
           p = PProf::ProvisioningProfile.new(file)
@@ -204,7 +204,7 @@ module PProf
     # Prints the filtered list of UUIDs or Paths only
     #
     # @param [String] dir
-    #        The directory containing the mobileprovision files to list.
+    #        The directory containing the mobileprovision/provisionprofile files to list.
     #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     # @param [Hash] options
     #        The options hash typically filled while parsing the command line arguments.
@@ -217,7 +217,7 @@ module PProf
     #
     def print_list(dir: PProf::ProvisioningProfile::DEFAULT_DIR, options:) # rubocop:disable Style/OptionalArguments
       errors = []
-      Dir['*.mobileprovision', base: dir].each do |file_name|
+      Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
         file = File.join(dir, file_name)
         p = PProf::ProvisioningProfile.new(file)
         next if block_given? && !yield(p)
@@ -233,7 +233,7 @@ module PProf
     # Prints the filtered list of profiles as a JSON array
     #
     # @param [String] dir
-    #        The directory containing the mobileprovision files to list.
+    #        The directory containing the mobileprovision/provisionprofile files to list.
     #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
     # @param [Hash] options
     #        The options hash typically filled while parsing the command line arguments.
@@ -246,7 +246,7 @@ module PProf
     #
     def print_json_list(dir: PProf::ProvisioningProfile::DEFAULT_DIR, options:) # rubocop:disable Style/OptionalArguments
       errors = []
-      profiles = Dir['*.mobileprovision', base: dir].map do |file_name|
+      profiles = Dir['*.{mobileprovision,provisionprofile}', base: dir].map do |file_name|
         file = File.join(dir, file_name)
         p = PProf::ProvisioningProfile.new(file)
         as_json(p, options) unless block_given? && !yield(p)

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -21,7 +21,7 @@ module PProf
     #        File path or UUID of the ProvisioningProfile
     #
     def initialize(file)
-      path = if file.match? /^[0-9A-F-]*$/i
+      path = if file.match?(/^[0-9A-F-]*$/i)
                Dir["#{PProf::ProvisioningProfile::DEFAULT_DIR}/#{file}.{mobileprovision,provisionprofile}"].first
              else
                file

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -21,11 +21,13 @@ module PProf
     #        File path or UUID of the ProvisioningProfile
     #
     def initialize(file)
-      path = if file =~ /^[0-9A-F-]*$/i
-               "#{PProf::ProvisioningProfile::DEFAULT_DIR}/#{file}.mobileprovision"
+      path = if file.match? /^[0-9A-F-]*$/i
+               Dir["#{PProf::ProvisioningProfile::DEFAULT_DIR}/#{file}.{mobileprovision,provisionprofile}"].first
              else
                file
              end
+      raise "Unable to find Provisioning Profile with UUID #{file}." if file.nil?
+
       xml = nil
       begin
         pkcs7 = OpenSSL::PKCS7.new(File.read(path))
@@ -41,7 +43,7 @@ module PProf
         xml = `security cms -D -i "#{path}" 2> /dev/null`
       end
       @plist = Plist.parse_xml(xml)
-      raise "Unable to parse file #{file}." if @plist.nil?
+      raise "Unable to parse file #{path}." if @plist.nil?
     end
 
     # The name of the Provisioning Profile

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -60,6 +60,14 @@ module PProf
       @plist['UUID']
     end
 
+    # The list of Platforms the Provisioning Profile is for.
+    # Typical values include `OSX`, `iOS`, `xrOS`, `visionOS`, …
+    #
+    # @return [Array<String>]
+    def platform
+      @plist['Platform']
+    end
+
     # The name of the Application Identifier associated with this Provisioning Profile
     #
     # @note This is not the AppID itself, but rather the name you associated to that


### PR DESCRIPTION
- **Add support for Mac profiles (`*.provisionprofile`)**
- **Address rubocop violations**
- **Add filter option for `--platform`**
