### PR TITLE
Add support for new Profiles location since macOS Sequoia

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ File.open('certs.txt', 'w') do |file|
 end
 
 # And you can easily loop on all provisioning profiles and manipulate each
-dir = PProf::ProvisioningProfile::DEFAULT_DIR
+profiles_dirs = PProf::ProvisioningProfile::DEFAULT_DIRS
 # `*.mobileprovision` are typically for iOS profiles, `*.provisionprofile` for Mac profiles
-Dir["#{dir}/*.{mobileprovision,provisionprofile}"].each do |file|
-  p = PProf::ProvisioningProfile.new(file)
-  puts p.name
+profiles_dirs.each do |dir|
+  Dir["#{dir}/*.{mobileprovision,provisionprofile}"].each do |file|
+    p = PProf::ProvisioningProfile.new(file)
+    puts p.name
+  end
 end
 ```
 
@@ -149,7 +151,7 @@ That plist payload itself contains various data, including some textual informat
 
 ```ruby
 PProf::ProvisioningProfile
-    ::DEFAULT_DIR
+    ::DEFAULT_DIRS
     new(file) => PProf::ProvisioningProfile
     to_hash => Hash<String, Any>
     

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -7,7 +7,7 @@ module PProf
   # A helper tool to pretty-print Provisioning Profile informations
   class OutputFormatter
     # List of properties of a `PProf::ProvisioningProfile` to print when using the `-i` flag
-    MAIN_PROFILE_KEYS = %i[name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name].freeze
+    MAIN_PROFILE_KEYS = %i[path name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name].freeze
 
     # Initialize a new OutputFormatter
     #
@@ -110,6 +110,7 @@ module PProf
     #
     def as_json(profile, options = {})
       hash = profile.to_hash.dup
+      hash['path'] = profile.path
       hash.delete 'DER-Encoded-Profile'
       hash.delete 'ProvisionedDevices' unless options[:devices]
       if options[:certs]

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -269,7 +269,7 @@ module PProf
       return false if actual.nil? # false if no Push entitlements
       return true if expected == true # true if Push present but we don't filter on specific env
 
-      actual =~ expected        # true if Push present and we filter on specific env
+      actual =~ expected # true if Push present and we filter on specific env
     end
   end
 end

--- a/lib/pprof/output_formatter.rb
+++ b/lib/pprof/output_formatter.rb
@@ -164,15 +164,15 @@ module PProf
 
     # Prints the filtered list as a table
     #
-    # @param [String] dir
-    #        The directory containing the mobileprovision/provisionprofile files to list.
-    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
+    # @param [String] dirs
+    #        The directories containing the mobileprovision/provisionprofile files to list.
+    #        Defaults to ['~/Library/MobileDevice/Provisioning Profiles', '~/Library/Developer/Xcode/UserData/Provisioning Profiles']
     #
     # @yield each provisioning provile for filtering/validation
     #        The block is given ProvisioningProfile object and should
     #        return true to display the row, false to filter it out
     #
-    def print_table(dir: PProf::ProvisioningProfile::DEFAULT_DIR)
+    def print_table(dirs: PProf::ProvisioningProfile::DEFAULT_DIRS)
       count = 0
       errors = []
 
@@ -181,19 +181,21 @@ module PProf
       @output.puts table.row('UUID', 'Name', 'AppID', 'Expiration Date', ' ', 'Team Name')
       @output.puts table.separator
 
-      Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
-        file = File.join(dir, file_name)
-        begin
-          p = PProf::ProvisioningProfile.new(file)
+      dirs.each do |dir|
+        Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
+          file = File.join(dir, file_name)
+          begin
+            p = PProf::ProvisioningProfile.new(file)
 
-          next if block_given? && !yield(p)
+            next if block_given? && !yield(p)
 
-          state = DateTime.now < p.expiration_date ? "\u{2705}" : "\u{274c}" # 2705=checkmark, 274C=red X
-          @output.puts table.row(p.uuid, p.name, p.entitlements.app_id, p.expiration_date.to_time, state, p.team_name)
-        rescue StandardError => e
-          errors << { message: e, file: file }
+            state = DateTime.now < p.expiration_date ? "\u{2705}" : "\u{274c}" # 2705=checkmark, 274C=red X
+            @output.puts table.row(p.uuid, p.name, p.entitlements.app_id, p.expiration_date.to_time, state, p.team_name)
+          rescue StandardError => e
+            errors << { message: e, file: file }
+          end
+          count += 1
         end
-        count += 1
       end
 
       @output.puts table.separator
@@ -208,25 +210,27 @@ module PProf
     #        The options hash typically filled while parsing the command line arguments.
     #         - :mode: will print the UUIDs if set to `:list`, the file path otherwise
     #         - :zero: will concatenate the entries with `\0` instead of `\n` if set
-    # @param [String] dir
-    #        The directory containing the mobileprovision/provisionprofile files to list.
-    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
+    # @param [String] dirs
+    #        The directories containing the mobileprovision/provisionprofile files to list.
+    #        Defaults to ['~/Library/MobileDevice/Provisioning Profiles', '~/Library/Developer/Xcode/UserData/Provisioning Profiles']
     #
     # @yield each provisioning profile for filtering/validation
     #        The block is given ProvisioningProfile object and should
     #        return true to display the row, false to filter it out
     #
-    def print_list(options:, dir: PProf::ProvisioningProfile::DEFAULT_DIR)
+    def print_list(options:, dirs: PProf::ProvisioningProfile::DEFAULT_DIRS)
       errors = []
-      Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
-        file = File.join(dir, file_name)
-        p = PProf::ProvisioningProfile.new(file)
-        next if block_given? && !yield(p)
+      dirs.each do |dir|
+        Dir['*.{mobileprovision,provisionprofile}', base: dir].each do |file_name|
+          file = File.join(dir, file_name)
+          p = PProf::ProvisioningProfile.new(file)
+          next if block_given? && !yield(p)
 
-        @output.print options[:mode] == :list ? p.uuid.chomp : file.chomp
-        @output.print options[:zero] ? "\0" : "\n"
-      rescue StandardError => e
-        errors << { message: e, file: file }
+          @output.print options[:mode] == :list ? p.uuid.chomp : file.chomp
+          @output.print options[:zero] ? "\0" : "\n"
+        rescue StandardError => e
+          errors << { message: e, file: file }
+        end
       end
       errors.each { |e| print_error(e[:message], e[:file]) } unless errors.empty?
     end
@@ -237,22 +241,24 @@ module PProf
     #        The options hash typically filled while parsing the command line arguments.
     #         - :certs: will print the UUIDs if set to `:list`, the file path otherwise
     #         - :devices: will concatenate the entries with `\0` instead of `\n` if set
-    # @param [String] dir
-    #        The directory containing the mobileprovision/provisionprofile files to list.
-    #        Defaults to '~/Library/MobileDevice/Provisioning Profiles'
+    # @param [String] dirs
+    #        The directories containing the mobileprovision/provisionprofile files to list.
+    #        Defaults to ['~/Library/MobileDevice/Provisioning Profiles', '~/Library/Developer/Xcode/UserData/Provisioning Profiles']
     #
     # @yield each provisioning profile for filtering/validation
     #        The block is given ProvisioningProfile object and should
     #        return true to display the row, false to filter it out
     #
-    def print_json_list(options:, dir: PProf::ProvisioningProfile::DEFAULT_DIR)
+    def print_json_list(options:, dirs: PProf::ProvisioningProfile::DEFAULT_DIRS)
       errors = []
-      profiles = Dir['*.{mobileprovision,provisionprofile}', base: dir].map do |file_name|
-        file = File.join(dir, file_name)
-        p = PProf::ProvisioningProfile.new(file)
-        as_json(p, options) unless block_given? && !yield(p)
-      rescue StandardError => e
-        errors << { message: e, file: file }
+      profiles = dirs.flat_map do |dir|
+        Dir['*.{mobileprovision,provisionprofile}', base: dir].map do |file_name|
+          file = File.join(dir, file_name)
+          p = PProf::ProvisioningProfile.new(file)
+          as_json(p, options) unless block_given? && !yield(p)
+        rescue StandardError => e
+          errors << { message: e, file: file }
+        end
       end.compact
       errors.each { |e| print_error(e[:message], e[:file]) } unless errors.empty?
       @output.puts JSON.pretty_generate(profiles)

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -171,7 +171,7 @@ module PProf
     #
     # @return [String]
     def to_s
-      lines = %i[name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name].map do |key|
+      lines = %i[path name uuid app_id_name app_id_prefix creation_date expiration_date ttl team_ids team_name].map do |key|
         "- #{key}: #{send(key.to_sym)}"
       end +
               [

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -10,8 +10,8 @@ module PProf
   class ProvisioningProfile
     # The default location where all the Provisioning Profiles are stored on a Mac
     DEFAULT_DIRS = [
-      File.join(ENV['HOME'], 'Library', 'MobileDevice', 'Provisioning Profiles'),
-      File.join(ENV['HOME'], 'Library', 'Developer', 'Xcode', 'UserData', 'Provisioning Profiles')
+      File.join(Dir.home, 'Library', 'MobileDevice', 'Provisioning Profiles'),
+      File.join(Dir.home, 'Library', 'Developer', 'Xcode', 'UserData', 'Provisioning Profiles')
     ].freeze
 
     attr_reader :path

--- a/lib/pprof/provisioning_profile.rb
+++ b/lib/pprof/provisioning_profile.rb
@@ -9,28 +9,35 @@ module PProf
   # Represents the content of a Provisioning Profile file
   class ProvisioningProfile
     # The default location where all the Provisioning Profiles are stored on a Mac
-    DEFAULT_DIR = "#{ENV['HOME']}/Library/MobileDevice/Provisioning Profiles"
+    DEFAULT_DIRS = [
+      File.join(ENV['HOME'], 'Library', 'MobileDevice', 'Provisioning Profiles'),
+      File.join(ENV['HOME'], 'Library', 'Developer', 'Xcode', 'UserData', 'Provisioning Profiles')
+    ].freeze
+
+    attr_reader :path
 
     # Create a new ProvisioningProfile object from a file path or UUID
     #
     # - If the parameter given has the form of an UUID, a file named with this UUID
-    #   and a `.mobileprovision` is searched in the default directory `DEFAULT_DIR`
+    #   and a `.mobileprovision` is searched in the default directories `DEFAULT_DIRS`
     # - Otherwise, the parameter is interpreted as a file path
     #
     # @param [String] file
     #        File path or UUID of the ProvisioningProfile
     #
     def initialize(file)
-      path = if file.match?(/^[0-9A-F-]*$/i)
-               Dir["#{PProf::ProvisioningProfile::DEFAULT_DIR}/#{file}.{mobileprovision,provisionprofile}"].first
-             else
-               file
-             end
-      raise "Unable to find Provisioning Profile with UUID #{file}." if file.nil?
+      @path = if file.match?(/^[0-9A-F-]*$/i)
+                PProf::ProvisioningProfile::DEFAULT_DIRS.flat_map do |dir|
+                  Dir["#{dir}/#{file}.{mobileprovision,provisionprofile}"]
+                end.compact.first
+              else
+                file
+              end
+      raise "Unable to find Provisioning Profile with UUID #{file}." if @path.nil?
 
       xml = nil
       begin
-        pkcs7 = OpenSSL::PKCS7.new(File.read(path))
+        pkcs7 = OpenSSL::PKCS7.new(File.read(@path))
         pkcs7.verify([], OpenSSL::X509::Store.new)
         xml = pkcs7.data
         raise 'Empty PKCS7 payload' if xml.nil? || xml.empty?
@@ -40,10 +47,10 @@ module PProf
         # So as a fallback, we run the `security` command line.
         # (We could use `security` everytime, but invoking a command line is generally less
         #  efficient than calling the OpenSSL gem if available, so for now it's just used as fallback)
-        xml = `security cms -D -i "#{path}" 2> /dev/null`
+        xml = `security cms -D -i "#{@path}" 2> /dev/null`
       end
       @plist = Plist.parse_xml(xml)
-      raise "Unable to parse file #{path}." if @plist.nil?
+      raise "Unable to parse file #{@path}." if @plist.nil?
     end
 
     # The name of the Provisioning Profile


### PR DESCRIPTION
- Add support for the new location for storing provisioning profiles since Sequoia (`~/Library/Developer/Xcode/UserData/Provisioning Profiles/`)
- Include the `path` to the provisioning profile in `-i` and `-j` outputs
